### PR TITLE
Question List Reverse odd length words in a string, utils only

### DIFF
--- a/src/Apis/types.ts
+++ b/src/Apis/types.ts
@@ -45,6 +45,7 @@ export enum Paths {
     contact = "/contact",
     profile = "/profile",
     questionEdit = "/questionEdit/:questionId",
+    QuestionListReversedStrings = "/QuestionListReversedStrings",
 }
 
 export enum API {

--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -12,6 +12,7 @@ import { MyQuestionProvider } from "../QuestionContext/QuestionContext";
 import { Paths } from "../../Apis/types";
 import { Profile } from "../Profile/Profile";
 import { QuestionEdit } from "../QuestionEdit/QuestionEdit";
+import { QuestionListReversedStrings } from "../QuestionListReversedStrings/QuestionListReversedStrings";
 
 function App() {
     const navigate: NavigateFunction = useNavigate();
@@ -34,6 +35,10 @@ function App() {
             <MyQuestionProvider>
                 <NavBar />
                 <Routes>
+                    <Route
+                        path={Paths.QuestionListReversedStrings}
+                        element={<QuestionListReversedStrings />}
+                    />
                     <Route
                         path={Paths.questionEdit}
                         element={<QuestionEdit />}

--- a/src/Components/QuestionListReversedStrings/QuestionListReversedStrings.tsx
+++ b/src/Components/QuestionListReversedStrings/QuestionListReversedStrings.tsx
@@ -11,7 +11,5 @@ export const QuestionListReversedStrings = () => {
         setNewQuestions(reverseStringsOddLength({ questions }));
     }, [questions]);
 
-    console.log(newQuestions);
-
     return <>hello</>;
 };

--- a/src/Components/QuestionListReversedStrings/QuestionListReversedStrings.tsx
+++ b/src/Components/QuestionListReversedStrings/QuestionListReversedStrings.tsx
@@ -1,0 +1,17 @@
+import { useContext, useEffect, useState } from "react";
+import { MyQuestionContext } from "../QuestionContext/QuestionContext";
+import { reverseStringsOddLength } from "./utils";
+import { Question } from "../../Apis/types";
+
+export const QuestionListReversedStrings = () => {
+    const { questions } = useContext(MyQuestionContext);
+    const [newQuestions, setNewQuestions] = useState<Question[]>(questions);
+
+    useEffect(() => {
+        setNewQuestions(reverseStringsOddLength({ questions }));
+    }, [questions]);
+
+    console.log(newQuestions);
+
+    return <>hello</>;
+};

--- a/src/Components/QuestionListReversedStrings/utils.ts
+++ b/src/Components/QuestionListReversedStrings/utils.ts
@@ -4,7 +4,7 @@ interface Props {
     questions: Question[];
 }
 
-const test = (string: string) => {
+const reverseOddWordsInSentence = (string: string) => {
     let newString = string.split(" ");
     return newString
         .map((word) => {
@@ -20,7 +20,9 @@ export const reverseStringsOddLength = ({ questions }: Props) => {
     let reverseStringQuestionsOdd = questions;
 
     const result = reverseStringQuestionsOdd.map((question) => {
-        return (question.question = test(question.question));
+        return (question.question = reverseOddWordsInSentence(
+            question.question
+        ));
     });
 
     result.forEach((question, index) => {

--- a/src/Components/QuestionListReversedStrings/utils.ts
+++ b/src/Components/QuestionListReversedStrings/utils.ts
@@ -1,0 +1,31 @@
+import { Question } from "../../Apis/types";
+
+interface Props {
+    questions: Question[];
+}
+
+const test = (string: string) => {
+    let newString = string.split(" ");
+    return newString
+        .map((word) => {
+            if (word.length % 2 !== 0) {
+                word = word.split("").reverse().join("");
+            }
+            return word;
+        })
+        .join(" ");
+};
+
+export const reverseStringsOddLength = ({ questions }: Props) => {
+    let reverseStringQuestionsOdd = questions;
+
+    const result = reverseStringQuestionsOdd.map((question) => {
+        return (question.question = test(question.question));
+    });
+
+    result.forEach((question, index) => {
+        reverseStringQuestionsOdd[index].question = question;
+    });
+
+    return reverseStringQuestionsOdd;
+};


### PR DESCRIPTION
<img width="1345" alt="image" src="https://user-images.githubusercontent.com/70910513/220725778-ec8f2cc0-1c05-4904-8f51-b5ca9022fce3.png">


question: when I don't have the `newQuestions = useState()` set as the state in QuestionListReversedStrings.tsx, and instead set as `newQuestions = function()` the odd length strings in utils will flip from correct to incorrect with each render, what I don't understand is that its functional code, so no matter how many times it runs it's still should work correctly? 

<img width="1345" alt="image" src="https://user-images.githubusercontent.com/70910513/220727144-66ad3318-9d51-4268-ba2a-7d6d8fb7765d.png">
